### PR TITLE
Android notifications and settings improvements

### DIFF
--- a/android/app/src/main/java/com/fra/plutomierz/receiver/PlutaReminderReceiver.kt
+++ b/android/app/src/main/java/com/fra/plutomierz/receiver/PlutaReminderReceiver.kt
@@ -1,18 +1,32 @@
 package com.fra.plutomierz.receiver
 
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import com.fra.plutomierz.ui.MainActivity
 
 class PlutaReminderReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
+        val launchIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
         val notification = NotificationCompat.Builder(context, "pluta_channel")
             .setSmallIcon(android.R.drawable.ic_dialog_info)
             .setContentTitle("Uwaga Pluta!")
             .setContentText("Skrót Pluty PDW!")
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
             .build()
 
         with(NotificationManagerCompat.from(context)) {

--- a/android/app/src/main/java/com/fra/plutomierz/ui/SettingsActivity.kt
+++ b/android/app/src/main/java/com/fra/plutomierz/ui/SettingsActivity.kt
@@ -1,9 +1,12 @@
 package com.fra.plutomierz.ui
 
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -12,17 +15,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.fra.plutomierz.data.PreferencesHelper
 import com.fra.plutomierz.ui.theme.PlutomierzTheme
 import com.fra.plutomierz.util.NotificationUtils
 
-/**
- * Activity for displaying the settings screen.
- */
 class SettingsActivity : ComponentActivity() {
-    /**
-     * Called when the activity is starting. This is where most initialization should go.
-     * @param savedInstanceState If the activity is being re-initialized after previously being shut down then this Bundle contains the data it most recently supplied in onSaveInstanceState(Bundle).
-     */
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,15 +31,13 @@ class SettingsActivity : ComponentActivity() {
     }
 }
 
-/**
- * Composable function for displaying the settings screen.
- * @param onBackPressed Callback function to be invoked when the back button is pressed.
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(onBackPressed: () -> Unit) {
     val context = LocalContext.current
+    val sharedPreferences = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
     var notificationsEnabled by remember { mutableStateOf(true) }
+    var nickname by remember { mutableStateOf(PreferencesHelper.getUsername(context) ?: "") }
 
     Scaffold(
         topBar = {
@@ -79,6 +74,22 @@ fun SettingsScreen(onBackPressed: () -> Unit) {
                     }
                 }
             )
+            Spacer(modifier = Modifier.padding(8.dp))
+            Text("Zmień nazwę Pluty")
+            TextField(
+                value = nickname,
+                onValueChange = { nickname = it },
+                label = { Text("Pluta") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Button(
+                onClick = {
+                    sharedPreferences.edit().putString("nickname", nickname).apply()
+                },
+                modifier = Modifier.padding(top = 8.dp)
+            ) {
+                Text("Zapisz")
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/fra/plutomierz/ui/SettingsActivity.kt
+++ b/android/app/src/main/java/com/fra/plutomierz/ui/SettingsActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import com.fra.plutomierz.data.PreferencesHelper
 import com.fra.plutomierz.ui.theme.PlutomierzTheme
 import com.fra.plutomierz.util.NotificationUtils
+import com.fra.plutomierz.utils.getRandomMotivationalText
 
 class SettingsActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
@@ -38,6 +39,8 @@ fun SettingsScreen(onBackPressed: () -> Unit) {
     val sharedPreferences = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
     var notificationsEnabled by remember { mutableStateOf(true) }
     var nickname by remember { mutableStateOf(PreferencesHelper.getUsername(context) ?: "") }
+    var tapCount by remember { mutableIntStateOf(0) }
+    var showEasterEgg by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -89,6 +92,26 @@ fun SettingsScreen(onBackPressed: () -> Unit) {
                 modifier = Modifier.padding(top = 8.dp)
             ) {
                 Text("Zapisz")
+            }
+            Spacer(modifier = Modifier.padding(8.dp))
+            Button(
+                onClick = {
+                    tapCount++
+                    if (tapCount >= 5) {
+                        showEasterEgg = true
+                        tapCount = 0
+                    }
+                },
+                modifier = Modifier
+                    .padding(top = 8.dp)
+            ) {
+                Text("DDOS PLUTY BOMBA W ŁĄCZNOŚĆ")
+            }
+            if (showEasterEgg) {
+                Text(
+                    text = getRandomMotivationalText(context),
+                    modifier = Modifier.padding(top = 16.dp)
+                )
             }
         }
     }


### PR DESCRIPTION
This pull request includes several changes to the `PlutaReminderReceiver` and `SettingsActivity` classes in the Android application. The most important changes include adding a pending intent to the notification in `PlutaReminderReceiver` and enhancing the settings screen with new features such as nickname change and an easter egg.

Enhancements to `PlutaReminderReceiver`:

* Added a pending intent to launch `MainActivity` when the notification is tapped.

Enhancements to `SettingsActivity`:

* Added new imports for `PreferencesHelper` and `getRandomMotivationalText` utilities.
* Introduced new state variables for nickname, tap count, and easter egge visibility.
* Added UI elements to change and save the nickname.
* Added a button to trigger an easter egg after five taps, displaying a random motivational text.