### PR TITLE
Add timestamps to chat messages.

### DIFF
--- a/api/src/db/handleMessageDb.ts
+++ b/api/src/db/handleMessageDb.ts
@@ -6,18 +6,21 @@ const saveMessageToDb = async (message: ChatMessage) => {
     await db.run(`
         INSERT INTO chat_messages (username, text, created_at)
         VALUES (?, ?, ?)
-    `, [message.username, message.text, new Date().toISOString()]);
+    `, [message.username, message.text, message.timestamp.toISOString()]);
 };
 
 const getLastMessagesFromDb = async (limit: number): Promise<ChatMessage[]> => {
     const db = await dbPromise;
     const messages = await db.all<ChatMessage[]>(`
-        SELECT username, text
+        SELECT username, text, created_at as timestamp
         FROM chat_messages
         ORDER BY created_at DESC
         LIMIT ?
     `, [limit]);
-    return messages.reverse();
+    return messages.map(message => ({
+        ...message,
+        timestamp: new Date(message.timestamp)
+    })).reverse();
 };
 
 export {saveMessageToDb, getLastMessagesFromDb};

--- a/api/src/types/ChatMessage.ts
+++ b/api/src/types/ChatMessage.ts
@@ -1,4 +1,5 @@
 export interface ChatMessage {
     username: string;
     text: string;
+    timestamp: Date;
 }


### PR DESCRIPTION
Timestamp is included in the message.
Example message from websocket:
```json
{
    "type": "message",
    "message": {
        "type": "message",
        "username": "Pluta",
        "text": "Wiadomka testowa, PDW!",
        "timestamp": "2024-12-11T16:14:49.877Z"
    }
}
```
The message that client sends to the api hasn't changed.