### PR TITLE
:sparkles: API: Broadcast onlajt users count

### DIFF
--- a/api/src/websocket/utils/activeUsersCount.ts
+++ b/api/src/websocket/utils/activeUsersCount.ts
@@ -1,0 +1,17 @@
+import wss from "./websocketServer";
+import {WebSocket} from "ws";
+
+const getActiveUsersCount = (): number => {
+    return Array.from(wss.clients).filter(client => client.readyState === WebSocket.OPEN).length;
+};
+
+const broadcastActiveUsersCount = (): void => {
+    const count = getActiveUsersCount();
+    wss.clients.forEach((client) => {
+        if (client.readyState === WebSocket.OPEN) {
+            client.send(JSON.stringify({type: 'activeUsers', count}));
+        }
+    });
+};
+
+export default broadcastActiveUsersCount;


### PR DESCRIPTION
This pull request introduces functionality to track and broadcast the count of active WebSocket users. The most important changes include the creation of a utility function to count active users, the broadcasting of this count to all connected clients, and the integration of these functionalities into the WebSocket server.

New utility functions for active user tracking:

* [`api/src/websocket/utils/activeUsersCount.ts`](diffhunk://#diff-f6a0ce4ac853e0bb199bf13b2211441ff9bd1c63dd1bf107cd1795ef7339e2c0R1-R17): Added a new utility module that defines `getActiveUsersCount` to count active WebSocket clients and `broadcastActiveUsersCount` to broadcast this count to all clients.

Integration with WebSocket server:

* [`api/src/websocket/websocket.ts`](diffhunk://#diff-1f16b70837f9bec466d186f82fff63a1544f48cc84d86be4c65a61977b9a69e8L6-R10): Imported the `broadcastActiveUsersCount` function and invoked it when a client connects and disconnects to keep all clients updated with the current active user count. [[1]](diffhunk://#diff-1f16b70837f9bec466d186f82fff63a1544f48cc84d86be4c65a61977b9a69e8L6-R10) [[2]](diffhunk://#diff-1f16b70837f9bec466d186f82fff63a1544f48cc84d86be4c65a61977b9a69e8R31) [[3]](diffhunk://#diff-1f16b70837f9bec466d186f82fff63a1544f48cc84d86be4c65a61977b9a69e8R86)

Code cleanup:

* [`api/src/websocket/websocket.ts`](diffhunk://#diff-1f16b70837f9bec466d186f82fff63a1544f48cc84d86be4c65a61977b9a69e8L6-R10): Removed duplicate import of `updatePlutaValue`.
* [`api/src/websocket/websocket.ts`](diffhunk://#diff-1f16b70837f9bec466d186f82fff63a1544f48cc84d86be4c65a61977b9a69e8L41): Removed an unnecessary blank line.