### PR TITLE
API: handle message type sent by client

### DIFF
--- a/api/src/websocket/websocket.ts
+++ b/api/src/websocket/websocket.ts
@@ -29,22 +29,6 @@ wss.on('connection', async (ws: WebSocket) => {
 
     ws.send(JSON.stringify({ type: 'pluta', value: plutaValue }));
 
-    ws.on('message', async (data: string) => {
-        let message;
-        try {
-            message = JSON.parse(data);
-        } catch (error) {
-            ws.send(JSON.stringify({ type: 'error', message: 'Invalid JSON format' }));
-            return;
-        }
-
-        if (message.type === 'getPlutaLog') {
-            const logs = await getPlutaLog(new Date(message.date));
-            ws.send(JSON.stringify({ type: 'plutaLog', value: logs }));
-            return;
-        }
-    });
-
     const messages = await getLastMessagesFromDb(MAX_MESSAGES);
     ws.send(JSON.stringify({ type: 'history', messages }));
 
@@ -66,6 +50,8 @@ wss.on('connection', async (ws: WebSocket) => {
             return;
         }
 
+        // currently the programme assumes that messages without a message type are chat messages, this is so that legacy code still functions
+        // in any future implementation please specify the message type to be chatMessage
         if (!message.type || message.type === 'chatMessage') {
             try {
                 const chatMessage: ChatMessage = message;
@@ -96,6 +82,11 @@ wss.on('connection', async (ws: WebSocket) => {
             } catch (error) {
                 ws.send(JSON.stringify({type: 'error', message: 'Invalid message format'}));
             }
+        }
+        if (message.type === 'getPlutaLog') {
+            const logs = await getPlutaLog(new Date(message.date));
+            ws.send(JSON.stringify({ type: 'plutaLog', value: logs }));
+            return;
         }
         // here you can add more message types
     });

--- a/api/src/websocket/websocket.ts
+++ b/api/src/websocket/websocket.ts
@@ -65,35 +65,39 @@ wss.on('connection', async (ws: WebSocket) => {
             }));
             return;
         }
-        try {
-            const chatMessage: ChatMessage = message;
 
-            const messageValidation = validateAndFormatMessage(chatMessage.text);
-            if (!messageValidation.valid) {
-                ws.send(JSON.stringify({ type: 'error', message: messageValidation.error }));
-                return;
-            }
+        if (!message.type || message.type === 'chatMessage') {
+            try {
+                const chatMessage: ChatMessage = message;
 
-            const nicknameValidation = validateAndFormatNickname(chatMessage.username);
-            if (!nicknameValidation.valid) {
-                ws.send(JSON.stringify({ type: 'error', message: nicknameValidation.error }));
-                return;
-            }
-
-            chatMessage.text = messageValidation.formattedMessage || '';
-            chatMessage.username = nicknameValidation.formattedNickname || '';
-            chatMessage.timestamp = new Date();
-
-            await saveMessageToDb(chatMessage);
-
-            wss.clients.forEach((client) => {
-                if (client.readyState === WebSocket.OPEN) {
-                    client.send(JSON.stringify({ type: 'message', message: chatMessage }));
+                const messageValidation = validateAndFormatMessage(chatMessage.text);
+                if (!messageValidation.valid) {
+                    ws.send(JSON.stringify({type: 'error', message: messageValidation.error}));
+                    return;
                 }
-            });
-        } catch (error) {
-            ws.send(JSON.stringify({ type: 'error', message: 'Invalid message format' }));
+
+                const nicknameValidation = validateAndFormatNickname(chatMessage.username);
+                if (!nicknameValidation.valid) {
+                    ws.send(JSON.stringify({type: 'error', message: nicknameValidation.error}));
+                    return;
+                }
+
+                chatMessage.text = messageValidation.formattedMessage || '';
+                chatMessage.username = nicknameValidation.formattedNickname || '';
+                chatMessage.timestamp = new Date();
+
+                await saveMessageToDb(chatMessage);
+
+                wss.clients.forEach((client) => {
+                    if (client.readyState === WebSocket.OPEN) {
+                        client.send(JSON.stringify({type: 'message', message: chatMessage}));
+                    }
+                });
+            } catch (error) {
+                ws.send(JSON.stringify({type: 'error', message: 'Invalid message format'}));
+            }
         }
+        // here you can add more message types
     });
 
     ws.on('close', () => {


### PR DESCRIPTION
Response to issue #22 

Enhancements to WebSocket message handling:

* Added a check to validate the message type and ensure it is either undefined or a 'chatMessage' before processing further. This prevents processing of other message types as chat messages.